### PR TITLE
fix: specify PyG index for pyg_lib to prevent PyPI confusion

### DIFF
--- a/linux_requirements.txt
+++ b/linux_requirements.txt
@@ -14,7 +14,7 @@ torchvision==0.14.1+cu116
 torchaudio==0.13.1
 -f https://data.pyg.org/whl/torch-1.13.0+cu116.html
 torch_geometric
-pyg_lib 
+pyg_lib==0.4.0
 torch_scatter 
 torch_sparse 
 torch_cluster 


### PR DESCRIPTION
`pyg_lib` in `linux_requirements.txt` is distributed by the PyTorch Geometric project at `https://data.pyg.org/whl/` and is not on the default PyPI index. A bare `pip install -r linux_requirements.txt` queries PyPI for it, where an attacker could register the name.

This PR adds the official PyG index URL.
